### PR TITLE
fix: remove leading / on windows

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,7 +4,12 @@ import fs from 'fs';
 
 import convict from 'convict';
 
-const pkgJSONPath = new URL('../../package.json', import.meta.url).pathname;
+let pkgJSONPath = new URL('../../package.json', import.meta.url).pathname;
+const isWin = process.platform === "win32";
+if(isWin) {
+  // remove leading / on windows
+  pkgJSONPath = pkgJSONPath.substring(1);
+}
 const pckage = JSON.parse(fs.readFileSync(pkgJSONPath, 'utf8'));
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Hey,

The leading / in the config path made it crash with a "file not found" on windows. This fixes that.